### PR TITLE
Get CpuID faster than wmi

### DIFF
--- a/libc.hwid.runner/libc.hwid.runner.csproj
+++ b/libc.hwid.runner/libc.hwid.runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <Version>4.1.0.0</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Saeid Farahi Mohassel</Authors>

--- a/libc.hwid/AppInfo.cs
+++ b/libc.hwid/AppInfo.cs
@@ -8,14 +8,14 @@ namespace libc.hwid {
     /// </summary>
     internal static class AppInfo {
         public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-        public static bool IsMacOS => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        public static bool IsMacOs => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         public static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
         /// <summary>
         ///     e.g: C:\
         /// </summary>
         public static string WindowsInstallationDirectory => Path.GetPathRoot(Environment.SystemDirectory);
         public static bool Is64 => Environment.Is64BitOperatingSystem;
-        public static string OSArch => Is64 ? "64" : "32";
+        public static string OsArch => Is64 ? "64" : "32";
         public static bool IsInDesignMode => LicenseManager.UsageMode == LicenseUsageMode.Designtime;
     }
 }

--- a/libc.hwid/Cmd.cs
+++ b/libc.hwid/Cmd.cs
@@ -11,7 +11,7 @@ namespace libc.hwid {
                     CreateNoWindow = o.CreateNoWindow,
                     WindowStyle = o.WindowStyle,
                     RedirectStandardOutput = o.RedirectStdOut,
-                    UseShellExecute = o.UseOSShell,
+                    UseShellExecute = o.UseOsShell,
                     WorkingDirectory = o.WorkingDirectory
                 }
             };
@@ -57,24 +57,24 @@ namespace libc.hwid {
         public CmdOptions(bool useOsShell = false, bool createNoWindow = true,
             ProcessWindowStyle windowStyle = ProcessWindowStyle.Hidden, bool redirectStdOut = true)
             : this() {
-            UseOSShell = useOsShell;
+            UseOsShell = useOsShell;
             CreateNoWindow = createNoWindow;
             WindowStyle = windowStyle;
             RedirectStdOut = redirectStdOut;
         }
         public static CmdOptions Default { get; }
-        public bool UseOSShell { get; set; }
+        public bool UseOsShell { get; set; }
         public bool CreateNoWindow { get; set; } = true;
         public ProcessWindowStyle WindowStyle { get; set; } = ProcessWindowStyle.Hidden;
         public bool RedirectStdOut { get; set; } = true;
         /// <summary>
-        ///     When the <see cref="UseOSShell"></see> property is false, gets or sets the working directory for the process
-        ///     to be started. When <see cref="UseOSShell"></see> is true, gets or sets the directory that contains the process to
+        ///     When the <see cref="UseOsShell"></see> property is false, gets or sets the working directory for the process
+        ///     to be started. When <see cref="UseOsShell"></see> is true, gets or sets the directory that contains the process to
         ///     be started.
         /// </summary>
         /// <returns>
-        ///     When <see cref="UseOSShell"></see> is true, the fully qualified name of the directory that contains the
-        ///     process to be started. When the <see cref="UseOSShell"></see> property is false, the working directory for the
+        ///     When <see cref="UseOsShell"></see> is true, the fully qualified name of the directory that contains the
+        ///     process to be started. When the <see cref="UseOsShell"></see> property is false, the working directory for the
         ///     process to be started. The default is an empty string ("").
         /// </returns>
         public string WorkingDirectory { get; set; }

--- a/libc.hwid/Helpers/Asm.cs
+++ b/libc.hwid/Helpers/Asm.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Text;
+
+namespace libc.hwid.Helpers
+{
+    public static class Asm
+    {
+        // Taken from https://stackoverflow.com/a/16487521/3673720
+
+        [DllImport("user32", EntryPoint = "CallWindowProcW", CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)] private static extern IntPtr CallWindowProcW([In] byte[] bytes, IntPtr hWnd, int msg, [In, Out] byte[] wParam, IntPtr lParam);
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("kernel32", CharSet = CharSet.Unicode, SetLastError = true)] public static extern bool VirtualProtect([In] byte[] bytes, IntPtr size, int newProtect, out int oldProtect);
+
+        const int PAGE_EXECUTE_READWRITE = 0x40;
+
+        public static string GetProcessorId()
+        {
+            byte[] sn = new byte[8];
+
+            if (!ExecuteCode(ref sn))
+                return "ND";
+
+            return string.Format("{0}{1}", BitConverter.ToUInt32(sn, 4).ToString("X8"), BitConverter.ToUInt32(sn, 0).ToString("X8"));
+        }
+
+        private static bool ExecuteCode(ref byte[] result)
+        {
+            int num;
+
+            /* The opcodes below implement a C function with the signature:
+             * __stdcall CpuIdWindowProc(hWnd, Msg, wParam, lParam);
+             * with wParam interpreted as a pointer pointing to an 8 byte unsigned character buffer.
+             * */
+
+            byte[] code_x86 = new byte[] {
+                0x55,                      /* push ebp */
+                0x89, 0xe5,                /* mov  ebp, esp */
+                0x57,                      /* push edi */
+                0x8b, 0x7d, 0x10,          /* mov  edi, [ebp+0x10] */
+                0x6a, 0x01,                /* push 0x1 */
+                0x58,                      /* pop  eax */
+                0x53,                      /* push ebx */
+                0x0f, 0xa2,                /* cpuid    */
+                0x89, 0x07,                /* mov  [edi], eax */
+                0x89, 0x57, 0x04,          /* mov  [edi+0x4], edx */
+                0x5b,                      /* pop  ebx */
+                0x5f,                      /* pop  edi */
+                0x89, 0xec,                /* mov  esp, ebp */
+                0x5d,                      /* pop  ebp */
+                0xc2, 0x10, 0x00,          /* ret  0x10 */
+            };
+            byte[] code_x64 = new byte[] {
+                0x53,                                     /* push rbx */
+                0x48, 0xc7, 0xc0, 0x01, 0x00, 0x00, 0x00, /* mov rax, 0x1 */
+                0x0f, 0xa2,                               /* cpuid */
+                0x41, 0x89, 0x00,                         /* mov [r8], eax */
+                0x41, 0x89, 0x50, 0x04,                   /* mov [r8+0x4], edx */
+                0x5b,                                     /* pop rbx */
+                0xc3,                                     /* ret */
+            };
+
+            byte[] asmCode = IsX64Process() ? ref code_x64 : ref code_x86;
+
+            IntPtr ptr = new IntPtr(asmCode.Length);
+
+            if (!VirtualProtect(asmCode, ptr, PAGE_EXECUTE_READWRITE, out num))
+                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+
+            ptr = new IntPtr(result.Length);
+
+            return (CallWindowProcW(asmCode, IntPtr.Zero, 0, result, ptr) != IntPtr.Zero);
+        }
+
+        private static bool IsX64Process()
+        {
+            return IntPtr.Size == 8;
+        }
+    }
+}
+

--- a/libc.hwid/libc.hwid.csproj
+++ b/libc.hwid/libc.hwid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <Version>4.1.0.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Saeid Farahi Mohassel</Authors>
@@ -12,6 +12,22 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\out\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net5.0|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net5.0|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I have changed the way to retrieve CpuID with some inline asm code (only for Windows plateform).
Here's the benchmark:

![image](https://user-images.githubusercontent.com/17864005/110481917-60d0d980-80e8-11eb-8a3a-5d98fcefce49.png)

This was a problem for me because I have a program with a TcpClient which uses your library, and when it's instanciated it generates a hwid. When I was doing my test, I had to instanciate > 4000 tcp clients and this was too slow.

Generating a HWID :
- Before : ~1.5 s
- Now : ~0.003 s

And added .NET 5 target